### PR TITLE
Update meta.yaml (bypass)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a81f3896c62c8cb7b8108a08be2204afd94ca10e9a401f8c48adab789d451822
+  url: https://github.com/kaust-halo/geeet/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 3ce4da6de2cd6fc18325d1e879f747ff0677f4f9acf1be73a8ffac1eeda57f78
 
 build:
   number: 0


### PR DESCRIPTION
Temporarily changing the source to use the tarball from github instead of from pip 

https://github.com/conda-forge/staged-recipes/blob/main/recipes/example/meta.yaml

so that `requirements_dev.txt` is included. This file wasn't included in the sdist uploaded to pip for v0.3.0, because it wasn't included in the MANIFEST.in file. This has been fixed in the repository, but will be reflected for the next release. 

TODO: change back to https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz for next release!

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
